### PR TITLE
jdTextEdit: Add setuptools to dependencies

### DIFF
--- a/app-editors/jdtextedit/jdtextedit-8.2.recipe
+++ b/app-editors/jdtextedit/jdtextedit-8.2.recipe
@@ -35,6 +35,7 @@ REQUIRES="
 	pyqt5_python38
 	qscintilla_python38
 	requests_python38
+	setuptools_python38
 	"
 
 BUILD_REQUIRES="


### PR DESCRIPTION
I totally forgot that programs that are installed with setuptools also need setuptools to run.